### PR TITLE
feat: Convert HTML to Jetpack Compose screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,8 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     debugImplementation("androidx.compose.ui:ui-tooling")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended:1.6.8")
+    implementation("io.coil-kt:coil-compose:2.5.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.core:core-ktx:1.8.0")
     // https://mvnrepository.com/artifact/org.maplibre.gl/android-sdk

--- a/app/src/main/java/com/mral/geektest/MainActivity.kt
+++ b/app/src/main/java/com/mral/geektest/MainActivity.kt
@@ -3,57 +3,22 @@ package com.mral.geektest
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import com.mral.geektest.ui.theme.MyComposeApplicationTheme
-import androidx.compose.ui.Alignment
-import androidx.compose.runtime.*                       // remember, mutableStateOf
-import com.google.android.gms.location.LocationServices
-import androidx.core.app.ActivityCompat
-import android.Manifest
-import android.content.pm.PackageManager
-import android.widget.Toast
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.LocationOn
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.ContextCompat
-// Pour KeyboardOptions et KeyboardType (Compose UI)
-import androidx.compose.ui.text.input.KeyboardType
-// Add these imports at the top of your file
-import androidx.compose.foundation.text.KeyboardOptions
-import android.os.Handler
-import android.os.Looper
-import org.json.JSONObject
-import java.io.IOException
-import android.graphics.Color as AndroidColor
-import android.content.Context
-import org.json.JSONException
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
+import com.mral.geektest.ui.medication.MedicationScreen
+import com.mral.geektest.ui.theme.MeditationTheme
 
-
-class MainActivity : androidx.activity.ComponentActivity() {
-    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            androidx.compose.material3.Surface(
-                color = androidx.compose.material3.MaterialTheme.colorScheme.background
-            ) {
-                androidx.compose.material3.Text(text = "Hello World!")
+            MeditationTheme {
+                // A surface container using the 'background' color from the theme
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    MedicationScreen()
+                }
             }
         }
     }

--- a/app/src/main/java/com/mral/geektest/ui/medication/MedicationScreen.kt
+++ b/app/src/main/java/com/mral/geektest/ui/medication/MedicationScreen.kt
@@ -1,0 +1,139 @@
+package com.mral.geektest.ui.medication
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Vaccines
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.mral.geektest.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MedicationScreen() {
+    Scaffold(
+        topBar = { TopBar() },
+        bottomBar = { BottomNavigationBar() }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            MainContent()
+        }
+    }
+}
+
+@Composable
+fun TopBar() {
+    TopAppBar(
+        title = {
+            Text(
+                text = "Bonjour, Alex",
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp
+            )
+        },
+        actions = {
+            IconButton(onClick = { /* TODO */ }) {
+                Icon(Icons.Default.Settings, contentDescription = "Settings")
+            }
+        }
+    )
+}
+
+@Composable
+fun MainContent() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        AsyncImage(
+            model = "https://lh3.googleusercontent.com/aida-public/AB6AXuD2r7y_mFXFe387LG7Stst4NVfBzwM3GMBxSII_v2gLXmw1_zeBoRjkdDhqEJZB-uyfIeyExG0FjmCc525uvE5ERO14ckB8HyJ5ZCU2NM2Cf33K8045FvFcYTOQ_2kMqwjuWF_OEE7KXUa-lLTbHeZ1sj18uplQcrL8PIE1wZLiHfRRClp2lfYtSge1nwXM-yta_EfZ7-WYPY6hTTxeJKtaJkihgbsMF8TmBnLBt_fSZOhpqJrnCBicawqPCqndUYWzgjZfl48VIvNs",
+            contentDescription = "Medication image",
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16 / 9f)
+                .clip(RoundedCornerShape(8.dp)),
+            contentScale = ContentScale.Crop
+        )
+        Text(
+            text = "Aucun médicament prévu",
+            fontWeight = FontWeight.Bold,
+            fontSize = 18.sp,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = "Vous n'avez aucun médicament prévu pour aujourd'hui. Ajoutez un médicament pour commencer.",
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
+            color = Color.Gray
+        )
+        Button(
+            onClick = { /* TODO */ },
+            shape = RoundedCornerShape(8.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFF0F2F4))
+        ) {
+            Text(text = "Ajouter un médicament", color = Color.Black)
+        }
+    }
+}
+
+@Composable
+fun BottomNavigationBar() {
+    NavigationBar {
+        NavigationBarItem(
+            icon = { Icon(Icons.Default.Home, contentDescription = "Accueil") },
+            label = { Text("Accueil") },
+            selected = true,
+            onClick = { }
+        )
+        NavigationBarItem(
+            icon = { Icon(Icons.Outlined.CalendarMonth, contentDescription = "Calendrier") },
+            label = { Text("Calendrier") },
+            selected = false,
+            onClick = { }
+        )
+        NavigationBarItem(
+            icon = { Icon(Icons.Outlined.Vaccines, contentDescription = "Médicaments") },
+            label = { Text("Médicaments") },
+            selected = false,
+            onClick = { }
+        )
+        NavigationBarItem(
+            icon = { Icon(Icons.Outlined.Person, contentDescription = "Profil") },
+            label = { Text("Profil") },
+            selected = false,
+            onClick = { }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MedicationScreenPreview() {
+    MedicationScreen()
+}


### PR DESCRIPTION
This commit introduces a new Jetpack Compose screen, `MedicationScreen`, which is a conversion of the provided HTML design.

The new screen includes:
- A top app bar with a title and a settings icon.
- A main content area with an image loaded from a URL, two text fields, and a button.
- A bottom navigation bar with four items.

The `MainActivity` has been updated to display this new screen.

The necessary dependencies for Coil (image loading) and Material Icons Extended have been added to the `build.gradle.kts` file.